### PR TITLE
CPP14.g4: Remove unused keyword

### DIFF
--- a/src/grammar/CPP14.g4
+++ b/src/grammar/CPP14.g4
@@ -1713,11 +1713,6 @@ While
 	'while'
 ;
 
-WStatic_cast
-:
-    'wstatic_cast'
-;
-
 /*Operators*/
 LeftParen
 :


### PR DESCRIPTION
remove keyword 'wstatic_cast'

Closes https://github.com/HyeockJinKim/WeakKeywordCpp/issues/16